### PR TITLE
Add GigaWorld-Policy 0.1 leaderboard submission

### DIFF
--- a/submissions/gwp01_2026_05_11.json
+++ b/submissions/gwp01_2026_05_11.json
@@ -1,5 +1,5 @@
 {
-    "model_name": "giga_world_policy_0.1",
+    "model_name": "GigaWorld-Policy 0.1",
     "policy_family": "GigaWorld-Policy",
     "date": "2026-05-11",
     "submission_source": "external",

--- a/submissions/gwp01_2026_05_11.json
+++ b/submissions/gwp01_2026_05_11.json
@@ -1,0 +1,14 @@
+{
+    "model_name": "giga_world_policy_0.1",
+    "policy_family": "GigaWorld-Policy",
+    "date": "2026-05-11",
+    "submission_source": "external",
+    "robocasa_version": "1.0.0",
+    "atomic_seen_success": 44.4,
+    "composite_seen_success": 11.8,
+    "composite_unseen_success": 2.9,
+    "code_url": "https://github.com/buyaojinchang/gigaworld_policy_01_robocasa_multi-task.git",
+    "commit_hash": "b9e491965584963b62c31115d8b6416851c155ef",
+    "checkpoint_url": "https://huggingface.co/HengtaoLi/gwp01-robocasa-multi-task/blob/main/model.pt",
+    "notes": "GigaWorld-Policy-0.1(for RoboCasa365) is a multi-task model that trained on human300 dataset"
+  }

--- a/submissions/gwp01_2026_05_11.json
+++ b/submissions/gwp01_2026_05_11.json
@@ -3,7 +3,7 @@
     "policy_family": "GigaWorld-Policy",
     "date": "2026-05-11",
     "submission_source": "external",
-    "robocasa_version": "1.0.0",
+    "robocasa_version": "1.0.1",
     "atomic_seen_success": 44.4,
     "composite_seen_success": 11.8,
     "composite_unseen_success": 2.9,


### PR DESCRIPTION
## Submission checklist

- [x] I added exactly one JSON file for this submission
- [x] I placed the file in the `submissions/` directory
- [x] My JSON follows the submission template in the README
- [x] I used `"N/A"` for any field that is unavailable or not applicable
- [x] I did not modify existing submission files unrelated to this PR

## Submission details

- Model name: giga_world_policy_0.1
- Policy family: GigaWorld-Policy
- Submission source: `external`
- Submission JSON filename: gwp01_2026_05_11.json
- RoboCasa version: 1.0.0
- Atomic-Seen success: 44.4
- Composite-Seen success: 11.8
- Composite-Unseen success: 2.9
- Code URL: https://github.com/buyaojinchang/gigaworld_policy_01_robocasa_multi-task
- Commit hash: b9e491965584963b62c31115d8b6416851c155ef
- Checkpoint URL: https://huggingface.co/HengtaoLi/gwp01-robocasa-multi-task/blob/main/model.pt

## Notes

GigaWorld-Policy-0.1 (for RoboCasa365) is a multi-task model trained on the human300 dataset. Evaluated on the three RoboCasa365 splits (Atomic-Seen / Composite-Seen / Composite-Unseen) following the official protocol.