### PR TITLE
Add Riemann-1.0 RoboCasa365 submission

### DIFF
--- a/submissions/Riemann-1.0_2026-08-20.json
+++ b/submissions/Riemann-1.0_2026-08-20.json
@@ -1,0 +1,21 @@
+{
+  "model_name": "Riemann-1.0",
+  "policy_family": "Riemann",
+  "date": "2026-08-20",
+  "submission_source": "external",
+  "robocasa_version": "1.0.1",
+  "atomic_seen_success": 79.44,
+  "composite_seen_success": 58.13,
+  "composite_unseen_success": 45.21,
+  "code_url": "https://github.com/Riemann-Dynamics/Riemann-1.0/tree/robcoasa365",
+  "commit_hash": "d9af9911594c8e52fc7681aaf3cde21a56aecc63",
+  "checkpoint_url": "https://huggingface.co/RiemannDynamics/Riemann-1-RoboCasa365",
+  "paper_link": "https://github.com/Riemann-Dynamics/Riemann-1.0-Website/blob/main/paper/Riemann-1.0.pdf",
+  "open_source": "no",
+  "wandb": "N/A",
+  "training_config": {
+    "batch_size": 128,
+    "num_training_steps": 200000
+  },
+  "notes": "Riemann-1.0 evaluated on the full 50 target tasks of the RoboCasa365. "
+}


### PR DESCRIPTION
Added a JSON file for Riemann-1.0 model submission with details including success rates and links.

## Submission checklist

- [x] I added exactly one JSON file for this submission
- [x] I placed the file in the `submissions/` directory
- [x] My JSON follows the submission template in the README
- [x] I used `"N/A"` for any field that is unavailable or not applicable
- [x] I did not modify existing submission files unrelated to this PR

## Notes (optional)
Submitting **Riemann-1.0** results on RoboCasa365 (robocasa 1.0.1), evaluated on the full 50 target tasks:

| split | success |
|---|---:|
| Atomic-Seen | 79.44 % |
| Composite-Seen | 58.13 % |
| Composite-Unseen | 45.21 % |

This is a closed-source submission (`"open_source": "no"`). Per the README, private access
for verification has been extended to @sepnasiriany:

- **Evaluation code** — `Riemann-Dynamics/Riemann-1.0`, branch `robcoasa365`, commit `d9af991` (read collaborator invitation sent)
- **Checkpoint** — `RiemannDynamics/Riemann-1-RoboCasa365` on Hugging Face

Please let us know if any additional access or artifacts are needed to reproduce the numbers.

Add any extra context for reviewers here. **Submission details are auto-generated from your JSON** in a bot comment on this PR (updated when you push changes).
