### PR TITLE
Harden PR summary workflow against untrusted pull-request input

### DIFF
--- a/.github/workflows/pr-submission-summary.yml
+++ b/.github/workflows/pr-submission-summary.yml
@@ -21,14 +21,29 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     steps:
+      # `workflow_dispatch` inputs arrive over the API as strings -- `type: number`
+      # drives the form widget, it is not a server-side guarantee -- and this value
+      # is interpolated into git refspecs downstream. Gate it to digits here so
+      # every later step can rely on it.
       - name: Resolve PR number
         id: pr
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            NUMBER="$DISPATCH_PR_NUMBER"
           else
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            NUMBER="$EVENT_PR_NUMBER"
           fi
+          if [[ ! "$NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Refusing PR number '$NUMBER' -- must be digits only"
+            exit 1
+          fi
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Checkout main
         uses: actions/checkout@v4
@@ -42,46 +57,79 @@ jobs:
           test -f scripts/generate_submission_markdown.py
 
       - name: Fetch PR head
+        shell: bash
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          git fetch origin \
-            "+refs/pull/${{ steps.pr.outputs.number }}/head:refs/remotes/pull/${{ steps.pr.outputs.number }}/head"
+          set -euo pipefail
+          git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
+      # Filenames in a PR are attacker-controlled. They reach a `run:` block here,
+      # so they are passed through env (data) rather than `${{ }}` (spliced into
+      # the script text), and every one is checked against an allowlist first.
       - name: Find changed submission JSON files
         id: changed
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_REF: refs/remotes/pull/${{ steps.pr.outputs.number }}/head
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # Bracket ranges are collation-dependent in POSIX ERE; pin the locale
+          # so the allowlist below means the same thing on every runner.
+          LC_ALL: C
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BASE_SHA="$(git merge-base HEAD "refs/remotes/pull/${{ steps.pr.outputs.number }}/head")"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BASE_SHA="$(git merge-base HEAD "$PR_REF")"
           else
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            BASE_SHA="$EVENT_BASE_SHA"
           fi
-          mapfile -t FILES < <(
-            git diff --name-only --diff-filter=ACM \
-              "$BASE_SHA" \
-              "refs/remotes/pull/${{ steps.pr.outputs.number }}/head" \
-              -- 'submissions/*.json'
-          )
+          # -z yields raw NUL-separated paths: git neither quotes them nor lets a
+          # newline in a filename forge extra lines in $GITHUB_OUTPUT.
+          # Written to a file rather than read from a process substitution, whose
+          # exit status `pipefail` does not cover -- a failing `git diff` would
+          # otherwise read as "no submissions changed".
+          if ! git diff -z --name-only --diff-filter=ACM \
+                 "$BASE_SHA" "$PR_REF" -- 'submissions/*.json' > "$RUNNER_TEMP/changed.z"; then
+            echo "::error::git diff failed while listing changed submissions"
+            exit 1
+          fi
+          mapfile -d '' -t FILES < "$RUNNER_TEMP/changed.z"
           if [ "${#FILES[@]}" -eq 0 ]; then
             echo "paths=" >> "$GITHUB_OUTPUT"
-          else
-            printf -v joined '%s ' "${FILES[@]}"
-            echo "paths=${joined%" "}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          for f in "${FILES[@]}"; do
+            if [[ ! "$f" =~ ^submissions/[A-Za-z0-9._-]+\.json$ ]]; then
+              echo "::error::Refusing submission path '$f' -- submission filenames must match submissions/[A-Za-z0-9._-]+.json"
+              exit 1
+            fi
+          done
+          printf -v joined '%s ' "${FILES[@]}"
+          echo "paths=${joined%" "}" >> "$GITHUB_OUTPUT"
 
       - name: Materialize submission JSON from PR head
         if: steps.changed.outputs.paths != ''
         shell: bash
+        env:
+          SUBMISSION_PATHS: ${{ steps.changed.outputs.paths }}
+          PR_REF: refs/remotes/pull/${{ steps.pr.outputs.number }}/head
         run: |
           set -euo pipefail
-          for f in ${{ steps.changed.outputs.paths }}; do
+          # Unquoted on purpose: a space-joined list, and the allowlist above
+          # guarantees no path contains a space or any shell metacharacter.
+          for f in $SUBMISSION_PATHS; do
+            case "$f" in
+              submissions/*.json) ;;
+              *) echo "::error::Refusing unexpected path '$f'"; exit 1 ;;
+            esac
             mkdir -p "$(dirname "$f")"
-            git show "refs/remotes/pull/${{ steps.pr.outputs.number }}/head:${f}" > "${f}"
+            git show "${PR_REF}:${f}" > "$f"
           done
 
       - name: Render comment body


### PR DESCRIPTION
Thanks for maintaining the RoboCasa365 leaderboard — the submission flow is a
pleasure to work with, and the PR summary bot in particular is a nice touch.

While reading through the workflows I noticed something in
`pr-submission-summary.yml` that I think is worth tightening, and it seemed more
useful to send a patch than an issue. Apologies if I've missed context here.

Because the workflow runs on `pull_request_target`, its job token is the
repository's rather than the fork's. Two of its steps build shell scripts by
interpolating `${{ ... }}` values that come from the pull request:

```yaml
for f in ${{ steps.changed.outputs.paths }}; do
```

Those values are file paths from `git diff` against the PR head. Since GitHub
substitutes `${{ }}` into the script text before bash parses it, the contents of
a filename end up treated as shell source rather than passed as an argument, and
git does allow shell metacharacters in filenames.

On scope, so this is easy to prioritise: the job declares `pull-requests: write`
and `contents: read` and references no secrets, and `ROBOCASA_WEB_PUSH_TOKEN` is
only used by `sync-robocasa-web.yml`, which doesn't run on pull requests — so the
deploy credential isn't exposed. It looked worth closing regardless, but it isn't
an emergency.

I've deliberately left the workflow's design alone. Checking out `main` rather
than the PR head is exactly right, and the comment explaining why is what made me
look closely at the rest. This only changes how the inputs are handled:

- PR-controlled values now reach `run:` blocks through `env:`, so they arrive as
  data rather than as script text.
- Paths are checked against `^submissions/[A-Za-z0-9._-]+\.json$` before use,
  with a clear error otherwise. All 13 current submissions already satisfy this.
- The PR number is constrained to digits, since it ends up in a git refspec.
  (`workflow_dispatch` inputs arrive over the API as strings — `type: number`
  drives the form widget rather than validating server-side.)
- `git diff` uses `-z`, so a newline in a filename can't forge extra lines in
  `$GITHUB_OUTPUT`, and writes to a file instead of a process substitution, whose
  exit status `pipefail` doesn't cover — previously a failing `git diff` would
  have read as "no submissions changed".
- `LC_ALL=C`, since ERE bracket ranges are collation-dependent.

To check it actually works rather than just looks right, I ran the reworked steps
under bash 5.1 against a real commit pair (`dbb25fa`, which added a submission):
one path found, allowlisted, and exactly one line written to `$GITHUB_OUTPUT`. I
also checked the allowlist both ways — it accepts every existing submission
filename and rejects paths containing shell metacharacters, spaces, or `../`.

Very happy to adjust any of this. If you'd rather allow a broader set of
filenames, the pattern only needs to be tight enough that a path can't carry
shell syntax, so there's plenty of room.

One other thing, entirely up to you: while working through this I put together a
pytest suite for the submission scripts — the schema gate's negative cases, the
`split_counts` duplication between `build_leaderboard.py` and `weighted_overall.py`,
the curated-field merge, and a check that no `${{ }}` expression gets spliced into
a `run:` block. I didn't want to drop a large unsolicited PR on you, so I've kept
it aside. Glad to send it along if it would be useful, and equally happy not to.
